### PR TITLE
Correct terminology for Java/Android SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Azure Communication Services capabilities are conceptually organized into six ar
 
 ### Package Links
 
-| Area           | JavaScript | .NET | Python | Java (JVM) | iOS | Android (Java) | Other                          |
+| Area           | JavaScript | .NET | Python | Java SE | iOS | Android | Other                          |
 | -------------- | ---------- | ---- | ------ | ---- | -------------- | -------------- | ------------------------------ |
 | Azure Resource Manager | -         | [nuget](https://www.nuget.org/packages/Azure.ResourceManager.Communication)    |   [PyPi](https://pypi.org/project/azure-mgmt-communication/)    |  -  | -              | -  | [Go via GitHub](https://github.com/Azure/azure-sdk-for-go/releases/tag/v46.3.0) |
 | Common         | [npm](https://www.npmjs.com/package/@azure/communication-common)         | [nuget](https://www.nuget.org/packages/Azure.Communication.Common/)    | N/A      | [Maven](https://search.maven.org/search?q=a:azure-communication-common)   | [Swift via GitHub](https://github.com/Azure/azure-sdk-for-ios/releases/tag/1.0.0-beta.1)            | [Maven](https://search.maven.org/artifact/com.azure.android/azure-communication-common)             | -                              |


### PR DESCRIPTION
Java SE is the correct terminology.

Thanks,
Bruno Borges
PM, Java
Microsoft DevDiv