### PR TITLE
moving joinGroup to configuration + end

### DIFF
--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/App.tsx
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/App.tsx
@@ -5,7 +5,7 @@ import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import { reducer } from './core/reducers';
 import thunk from 'redux-thunk';
-import EndCall from './components/EndCall';
+import EndCall from './containers/EndCall';
 import HomeScreen from './components/HomeScreen';
 import ConfigurationScreen from './containers/Configuration';
 import { v1 as createGUID } from 'uuid';

--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/components/Configuration.tsx
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/components/Configuration.tsx
@@ -31,6 +31,7 @@ export interface ConfigurationScreenProps {
   setUserId(userId: string): void;
   initCallClient(userId: string, unsupportedStateHandler: () => void, endCallhandler: () => void): void;
   setGroup(groupId: string): void;
+  joinGroup(): void;
   startCallHandler(): void;
   unsupportedStateHandler: () => void;
   endCallHandler: () => void;
@@ -104,6 +105,8 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
                     props.setUserId(name);
                     props.callAgent.updateDisplayName(name);
                     props.startCallHandler();
+                    props.joinGroup();
+                    document.title = `${groupId} group call sample`;
                   }
                 }}
               >

--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/components/EndCall.tsx
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/components/EndCall.tsx
@@ -14,6 +14,7 @@ import {
 } from './styles/EndCall.styles';
 
 export interface EndCallProps {
+  joinGroup(): void;
   rejoinHandler(): void;
   homeHandler(): void;
 }
@@ -28,7 +29,7 @@ export default (props: EndCallProps): JSX.Element => {
       <Stack tokens={upperStackTokens}>
         <div className={endCallTitleStyle}>{leftCall}</div>
         <Stack horizontal tokens={buttonsStackTokens}>
-          <PrimaryButton className={buttonStyle} onClick={props.rejoinHandler}>
+          <PrimaryButton className={buttonStyle} onClick={() => { props.joinGroup(); props.rejoinHandler()}}>
             <VideoCameraEmphasisIcon className={videoCameraIconStyle} size="medium" />
             {rejoinCall}
           </PrimaryButton>

--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/components/GroupCall.tsx
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/components/GroupCall.tsx
@@ -1,5 +1,5 @@
 // © Microsoft Corporation. All rights reserved.
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Label, Overlay, Stack } from '@fluentui/react';
 import Header from '../containers/Header';
 import MediaGallery from '../containers/MediaGallery';
@@ -55,15 +55,6 @@ export interface GroupCallProps {
 export default (props: GroupCallProps): JSX.Element => {
   const [selectedPane, setSelectedPane] = useState(CommandPanelTypes.None);
   const activeScreenShare = props.screenShareStreams && props.screenShareStreams.length === 1;
-
-  const { callAgent, call, groupId, joinGroup } = props;
-
-  useEffect(() => {
-    if (callAgent && !call) {
-      joinGroup();
-      document.title = `${groupId} group call sample`;
-    }
-  }, [callAgent, call, groupId, joinGroup]);
 
   return (
     <Stack horizontalAlign="center" verticalAlign="center" styles={containerStyles}>

--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/containers/Configuration.ts
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/containers/Configuration.ts
@@ -3,7 +3,7 @@ import ConfigurationScreen, { ConfigurationScreenProps } from '../components/Con
 import { setGroup } from '../core/actions/calls';
 import { setUserId } from '../core/actions/sdk';
 import { setVideoDeviceInfo, setAudioDeviceInfo } from '../core/actions/devices';
-import { initCallClient, updateDevices } from '../core/sideEffects';
+import { joinGroup, initCallClient, updateDevices } from '../core/sideEffects';
 import { setMic } from '../core/actions/controls';
 import { State } from '../core/reducers';
 import { AudioDeviceInfo, VideoDeviceInfo, LocalVideoStream } from '@azure/communication-calling';
@@ -22,7 +22,19 @@ const mapStateToProps = (state: State, props: ConfigurationScreenProps) => ({
   videoDeviceList: state.devices.videoDeviceList,
   audioDeviceList: state.devices.audioDeviceList,
   cameraPermission: state.devices.cameraPermission,
-  microphonePermission: state.devices.microphonePermission
+  microphonePermission: state.devices.microphonePermission,
+  joinGroup: () => {
+    state.calls.callAgent &&
+      joinGroup(
+        state.calls.callAgent,
+        {
+          groupId: state.calls.group
+        },
+        {
+          audioOptions: { muted: !state.controls.mic }
+        }
+      );
+  }
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/containers/EndCall.ts
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/containers/EndCall.ts
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux';
+import { State } from '../core/reducers';
+import EndCall, { EndCallProps } from '../components/EndCall';
+import { joinGroup } from '../core/sideEffects';
+
+const mapStateToProps = (state: State, props: EndCallProps) => ({
+  joinGroup: () => {
+    state.calls.callAgent &&
+      joinGroup(
+        state.calls.callAgent,
+        {
+          groupId: state.calls.group
+        },
+        {
+          audioOptions: { muted: !state.controls.mic }
+        }
+      );
+  },
+  rejoinHandler: props.rejoinHandler,
+  homeHandler: props.homeHandler
+});
+
+const connector: any = connect(mapStateToProps, undefined);
+export default connector(EndCall);

--- a/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/containers/GroupCall.ts
+++ b/samples/Group Calling Hero Sample/Web/Calling/ClientApp/src/containers/GroupCall.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import GroupCall, { GroupCallProps } from '../components/GroupCall';
-import { joinGroup, setMicrophone } from '../core/sideEffects';
+import { setMicrophone } from '../core/sideEffects';
 import { setLocalVideoStream } from '../core/actions/streams';
 import { setVideoDeviceInfo, setAudioDeviceInfo } from '../core/actions/devices';
 import { AudioDeviceInfo, VideoDeviceInfo, LocalVideoStream } from '@azure/communication-calling';
@@ -16,18 +16,6 @@ const mapStateToProps = (state: State, props: GroupCallProps) => ({
   mic: state.controls.mic,
   groupCallEndReason: state.calls.groupCallEndReason,
   isGroup: () => state.calls.call && !state.calls.call.isIncoming && !!state.calls.group,
-  joinGroup: () => {
-    state.calls.callAgent &&
-      joinGroup(
-        state.calls.callAgent,
-        {
-          groupId: state.calls.group
-        },
-        {
-          audioOptions: { muted: !state.controls.mic }
-        }
-      );
-  },
   remoteParticipants: state.calls.remoteParticipants,
   streams: state.streams.streams,
   callState: state.calls.callState,


### PR DESCRIPTION
There was an issue where we can fail to join the call. Since the join logic was on the groupcall.tsx screen it would just attempt to join again. (Infinite loop) (Current hypothesis is VPN)

Now we try to join the call from the adjacent screens so at the very least if there is a call connection failure. We will not keep retrying.

We are waiting on an update with the SDK where we will have correct call end reasons and at that point we will be able to properly give messaging as to why the developer is in this strange state.